### PR TITLE
fix: close outbound chan after waiting for 10 minutes

### DIFF
--- a/util/stream.go
+++ b/util/stream.go
@@ -89,13 +89,15 @@ func (m *MessageStream) outbound() {
 			m.conn.Close()
 			// clear Outbound chan
 			go func() {
+			clearLoop:
 				for {
 					select {
 					case <-m.Outbound:
-					case <-time.After(time.Minute * 2):
-						return
+					case <-time.After(time.Minute * 10):
+						break clearLoop
 					}
 				}
+				close(m.Outbound)
 			}()
 			for i := 0; i < numParserGoroutines; i++ {
 				m.parserShutdown <- true


### PR DESCRIPTION
1. some extreme cases take a long time to process reconnection
2. close chan is not safe in receiver side, but fatal and restart is much better than hang up